### PR TITLE
Fixed chunking logic

### DIFF
--- a/src/AppleLossless/ConsoleHelper.cs
+++ b/src/AppleLossless/ConsoleHelper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace AppleLossless
+﻿namespace AppleLossless
 {
     internal static class ConsoleHelper
     {

--- a/src/AppleLossless/ConsoleHelper.cs
+++ b/src/AppleLossless/ConsoleHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace AppleLossless
+﻿using System;
+
+namespace AppleLossless
 {
     internal static class ConsoleHelper
     {

--- a/src/AppleLossless/ConverterService.cs
+++ b/src/AppleLossless/ConverterService.cs
@@ -77,7 +77,6 @@ namespace AppleLossless
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            _ffmpeg?.Dispose();
             return Task.CompletedTask;
         }
 

--- a/src/AppleLossless/FFmpegHelper.cs
+++ b/src/AppleLossless/FFmpegHelper.cs
@@ -1,10 +1,10 @@
-﻿using System.Diagnostics;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+using System.IO;
 
 namespace AppleLossless
 {
-    internal class FFmpegHelper : IDisposable
+    internal class FFmpegHelper
     {
         private static readonly string[] _mimes = new string[] {
             "flac", "m3u", "m3u8", "m4a", "m4b", "mp3", "ogg",
@@ -28,74 +28,68 @@ namespace AppleLossless
 
         public async Task StartAsync(CancellationToken token = default)
         {
-            var chunkSize = _files.Count <= _threadCount
-                ? _files.Count
-                : _threadCount;
+            var chunkSize = (_files.Count - 1) / _threadCount + 1;
 
             var chunks = _files.Chunk(chunkSize);
             _logger.LogInformation("Splitting job into {Count} chunks of {Size} size", chunks.Count(), chunkSize);
 
-            var maxMs = 0L;
-            var i = 0;
-            foreach (var chunk in chunks)
+
+            var sw = Stopwatch.StartNew();
+            var tasks = chunks.Select((chunk, index) => ProcessChunkAsync(chunk, index, token));
+            await Task.WhenAll(tasks);
+
+            sw.Stop();
+            _logger.LogInformation("Every chunk has been successfully completed in {Ms} ms", sw.ElapsedMilliseconds);
+        }
+
+        private async Task ProcessChunkAsync(string[] chunk, int chunkIndex, CancellationToken token = default)
+        {
+            _logger.LogInformation("Processing chunk #{Count}. {FileCount} files to convert", chunkIndex, chunk.Length);
+
+            foreach (var file in chunk)
             {
-                _logger.LogInformation("Processing chunk #{Count}. {FileCount} files to convert", i, chunk.Length);
-
-                var sw = Stopwatch.StartNew();
-                var tasks = new List<Task>();
-                foreach (var file in chunk)
+                var fileInfo = new FileInfo(file);
+                if (!fileInfo.Exists)
                 {
-                    var fileInfo = new FileInfo(file);
-                    if (!fileInfo.Exists)
-                    {
-                        _logger.LogError("The file at path {Path} doesn't exist anymore. Ignoring it", fileInfo.FullName);
-                        continue;
-                    }
-
-                    _logger.LogInformation("Converting {File} to format {Format}", fileInfo.Name, _options.Format);
-
-                    tasks.Add(Task.Run(async () =>
-                    {
-                        var destinationName = Path.Combine(_options.DestinationPath, fileInfo.FullName[(_options.SourcePath.Length + 1)..]);
-                        var currentExtension = Path.GetExtension(destinationName);
-                        var destinationExtension = _options.Format;
-                        if (!destinationExtension.StartsWith('.'))
-                        {
-                            destinationExtension = destinationExtension.Insert(0, ".");
-                        }
-
-                        destinationName = destinationName.Replace(currentExtension, destinationExtension);
-
-                        if (File.Exists(destinationName))
-                        {
-                            _logger.LogWarning("The file at path {Path} already exist. Ignoring it", fileInfo.FullName);
-                            return;
-                        }
-
-                        Directory.CreateDirectory(Path.GetDirectoryName(destinationName)!);
-
-                        var process = Process.Start(new ProcessStartInfo
-                        {
-                            FileName = _ffmpeg.FullName,
-                            Arguments = $"-hide_banner -loglevel error -i \"{fileInfo.FullName}\" -acodec alac \"{destinationName}\""
-                        });
-
-                        await process!.WaitForExitAsync(token);
-
-                        _logger.LogInformation("Converting {File} succeeded!", Path.GetFileName(destinationName));
-                    }, token));
+                    _logger.LogError("The file at path {Path} doesn't exist anymore. Ignoring it", fileInfo.FullName);
+                    continue;
                 }
 
-                await Task.WhenAll(tasks);
+                _logger.LogInformation("Converting {File} to format {Format}", fileInfo.Name, _options.Format);
 
-                sw.Stop();
-                maxMs += sw.ElapsedMilliseconds;
-                _logger.LogInformation("Completed chunk {Chunk} in {Time} ms.", i, sw.ElapsedMilliseconds);
+                await ConvertFileAsync(fileInfo, token);
+            }
+        }
 
-                i++;
+        private async Task ConvertFileAsync(FileInfo fileInfo, CancellationToken token = default)
+        {
+            var destinationName = Path.Combine(_options.DestinationPath, fileInfo.FullName[(_options.SourcePath.Length + 1)..]);
+            var currentExtension = Path.GetExtension(destinationName);
+            var destinationExtension = _options.Format;
+            if (!destinationExtension.StartsWith('.'))
+            {
+                destinationExtension = destinationExtension.Insert(0, ".");
             }
 
-            _logger.LogInformation("Every chunk has been successfully completed in {Ms} ms", maxMs);
+            destinationName = destinationName.Replace(currentExtension, destinationExtension);
+
+            if (File.Exists(destinationName))
+{
+                _logger.LogWarning("The file at path {Path} already exist. Ignoring it", fileInfo.FullName);
+                return;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationName)!);
+
+            var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = _ffmpeg.FullName,
+                Arguments = $"-hide_banner -loglevel error -i \"{fileInfo.FullName}\" -map a:0 -acodec alac \"{destinationName}\""
+            });
+
+            await process!.WaitForExitAsync(token);
+
+            _logger.LogInformation("Converting {File} succeeded!", Path.GetFileName(destinationName));
         }
 
         public static bool Exists(string? path, out string? truePath)
@@ -136,10 +130,6 @@ namespace AppleLossless
         public static bool IsSupportedMime(string extension)
         {
             return _mimes.Contains(extension);
-        }
-
-        public void Dispose()
-        {
         }
     }
 }

--- a/src/AppleLossless/FFmpegHelper.cs
+++ b/src/AppleLossless/FFmpegHelper.cs
@@ -82,7 +82,7 @@ namespace AppleLossless
             var process = Process.Start(new ProcessStartInfo
             {
                 FileName = _ffmpeg.FullName,
-                Arguments = $"-hide_banner -loglevel error -i \"{fileInfo.FullName}\" -map a:0 -acodec alac \"{destinationName}\""
+                Arguments = $"-hide_banner -loglevel error -i \"{fileInfo.FullName}\" -acodec alac \"{destinationName}\""
             });
 
             await process!.WaitForExitAsync(token);

--- a/src/AppleLossless/FFmpegHelper.cs
+++ b/src/AppleLossless/FFmpegHelper.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
-using System.Diagnostics;
-using System.IO;
+﻿using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 
 namespace AppleLossless
 {
@@ -32,7 +31,6 @@ namespace AppleLossless
 
             var chunks = _files.Chunk(chunkSize);
             _logger.LogInformation("Splitting job into {Count} chunks of {Size} size", chunks.Count(), chunkSize);
-
 
             var sw = Stopwatch.StartNew();
             var tasks = chunks.Select((chunk, index) => ProcessChunkAsync(chunk, index, token));


### PR DESCRIPTION
Old behaviour: setting thread count would yield N chunks with each containing thread count items, but then process them all in parallel anyway
New behaviour: creates thread count chunks of size M and then processes those in parallel
